### PR TITLE
Move firmware reset from R200 class into rsimpl::uvc::device

### DIFF
--- a/src/r200.cpp
+++ b/src/r200.cpp
@@ -15,11 +15,6 @@ namespace rsimpl
     {
     }
 
-    r200_camera::~r200_camera()
-	{
-    	rsimpl::ds::force_firmware_reset(get_device());
-	}
-
     void r200_camera::start_fw_logger(char /*fw_log_op_code*/, int /*grab_rate_in_ms*/, std::timed_mutex& /*mutex*/)
     {
         throw std::logic_error("Not implemented");

--- a/src/r200.h
+++ b/src/r200.h
@@ -14,7 +14,7 @@ namespace rsimpl
 
     public:
         r200_camera(std::shared_ptr<uvc::device> device, const static_device_info & info);
-        ~r200_camera();
+        ~r200_camera() {};
 
         virtual void start_fw_logger(char fw_log_op_code, int grab_rate_in_ms, std::timed_mutex& mutex) override;
         virtual void stop_fw_logger() override;

--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -34,6 +34,8 @@
 #include <linux/uvcvideo.h>
 #include <linux/videodev2.h>
 
+#include "ds-device.h"
+
 #pragma GCC diagnostic ignored "-Wpedantic"
 #include <libusb.h>
 #pragma GCC diagnostic pop
@@ -405,6 +407,8 @@ namespace rsimpl
 
                 if(usb_handle) libusb_close(usb_handle);
                 if(usb_device) libusb_unref_device(usb_device);
+
+                rsimpl::ds::force_firmware_reset(*this);
             }
 
             bool has_mi(int mi) const


### PR DESCRIPTION
- Ensures device is not reset while streaming is in progress at shutdown (avoid potention exceptions/errors from librealsense)
- Resets all realsense devices (issue occurs on others besides R200)