### PR TITLE
feat: PERCEPTION-2560: add std_msgs as a dependency to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>pkg-config</build_depend>
-
+  <build_depend>std_msgs</build_depend>
   <depend>libusb-1.0-dev</depend>
   <depend>linux-headers-generic</depend>
   <depend>libssl-dev</depend>


### PR DESCRIPTION
This change just adds std_msgs as a dependency to package.xml. This fixes a CMake build error (inside CLion) that allows the Clion to do proper type lookup and other developer live improvements.