### PR TITLE
Feature/modified intel branch

### DIFF
--- a/common/rendering.h
+++ b/common/rendering.h
@@ -417,7 +417,7 @@ namespace rs2
     // return the distance between p and the line created by p1 and p2
     inline float point_to_line_dist(float2 p1, float2 p2, float2 p)
     {
-        float d = abs((p2.x - p1.x)*(p1.y - p.y) - (p1.x - p.x)*(p2.y - p1.y)) / sqrt((p2.x - p1.x)*(p2.x - p1.x) + (p2.y - p1.y)*(p2.y - p1.y));
+        float d = std::abs((p2.x - p1.x)*(p1.y - p.y) - (p1.x - p.x)*(p2.y - p1.y)) / sqrt((p2.x - p1.x)*(p2.x - p1.x) + (p2.y - p1.y)*(p2.y - p1.y));
         return d;
     }
 

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1691,14 +1691,14 @@ namespace rs2
         auto x = static_cast<float>(-M_PI / 2);
         float _rx[4][4] = {
             { 1 , 0, 0, 0 },
-            { 0, cos(x), -sin(x), 0 },
-            { 0, sin(x), cos(x), 0 },
+            { 0, std::cos(x), -std::sin(x), 0 },
+            { 0, std::sin(x), std::cos(x), 0 },
             { 0, 0, 0, 1 }
         };
         auto z = static_cast<float>(M_PI);
         float _rz[4][4] = {
-            { cos(z), -sin(z),0, 0 },
-            { sin(z), cos(z), 0, 0 },
+            { std::cos(z), -std::sin(z),0, 0 },
+            { std::sin(z), std::cos(z), 0, 0 },
             { 0 , 0, 1, 0 },
             { 0, 0, 0, 1 }
         };

--- a/include/librealsense2/h/rs_sensor.h
+++ b/include/librealsense2/h/rs_sensor.h
@@ -226,6 +226,8 @@ void rs2_open_multiple(rs2_sensor* device, const rs2_stream_profile** profiles, 
 */
 void rs2_close(const rs2_sensor* sensor, rs2_error** error);
 
+int rs2_is_streaming(const rs2_sensor* sensor, rs2_error** error);
+
 /**
 * start streaming from specified configured sensor
 * \param[in] sensor  RealSense device

--- a/include/librealsense2/hpp/rs_sensor.hpp
+++ b/include/librealsense2/hpp/rs_sensor.hpp
@@ -200,6 +200,14 @@ namespace rs2
             error::handle(e);
         }
 
+        bool is_streaming() const
+        {
+            rs2_error* e = nullptr;
+            bool result = static_cast<bool>(rs2_is_streaming(_sensor.get(), &e));
+            error::handle(e);
+            return result;
+        }
+
         /**
         * register notifications callback
         * \param[in] callback   notifications callback

--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -14,6 +14,7 @@
 #include <stdint.h>
 #include <math.h>
 #include <float.h>
+#include <cmath>
 
 /* Given a point in 3D space, compute the corresponding pixel coordinates in an image with no distortion or forward distortion coefficients produced by the same camera */
 static void rs2_project_point_to_pixel(float pixel[2], const struct rs2_intrinsics * intrin, const float point[3])
@@ -93,7 +94,7 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
         for (int i = 0; i < 4; i++)
         {
             float f = theta*(1 + theta2*(intrin->coeffs[0] + theta2*(intrin->coeffs[1] + theta2*(intrin->coeffs[2] + theta2*intrin->coeffs[3])))) - rd;
-            if (abs(f) < FLT_EPSILON)
+            if (std::abs(f) < FLT_EPSILON)
             {
                 break;
             }

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -702,6 +702,13 @@ void rs2_stop(const rs2_sensor* sensor, rs2_error** error) BEGIN_API_CALL
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, sensor)
 
+int rs2_is_streaming(const rs2_sensor* sensor, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(sensor);
+    return static_cast<int>(sensor->sensor->is_streaming());
+}
+HANDLE_EXCEPTIONS_AND_RETURN(0, sensor)
+
 int rs2_supports_frame_metadata(const rs2_frame* frame, rs2_frame_metadata_value frame_metadata, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(frame);


### PR DESCRIPTION
Upgrade librealsense drivers and backport code from current implementaiton
We tell the compiler to use std:: c++ implementation of math functions such as abs, sin, cos, etc to prevent the compiler from attempting to use c library implementations and throwing warnings (or compile time errors) about being unable to convert types

We add is_streaming interface for two reasons: 1) to ensure that device is streaming before trying to shut down streams 2) to verify that device exist and is not null to prevent segmentation faults 